### PR TITLE
Combine and reorganize Application.AppSpec and Canvas.Input

### DIFF
--- a/examples/bouncing-ball/src/Main.purs
+++ b/examples/bouncing-ball/src/Main.purs
@@ -7,9 +7,7 @@ import Data.Number (pi)
 import Effect (Effect)
 import Gesso as Gesso
 import Gesso.Application as GApp
-import Gesso.Canvas as GCan
 import Gesso.Geometry as GGeo
-import Gesso.Interactions as GInt
 import Gesso.Time as GTime
 import Gesso.Util.Lerp as GLerp
 import Graphics.Canvas as Canvas
@@ -23,18 +21,16 @@ main =
 type State =
   { x :: Number, vx :: Number, y :: Number, vy :: Number, radius :: Number }
 
-canvasInput :: forall i o. GCan.Input State i o
+canvasInput :: forall i o. GApp.AppSpec State i o
 canvasInput =
   { name: "bouncing-ball"
-  , localState: { x: 0.0, vx: 1.0, y: 0.0, vy: 1.0, radius: 25.0 }
-  , app:
-      GApp.defaultApp
-        { window = GApp.Fullscreen
-        , render = render
-        , update = update
-        }
+  , initialState: { x: 0.0, vx: 1.0, y: 0.0, vy: 1.0, radius: 25.0 }
   , viewBox: { x: 0.0, y: 0.0, width: 1920.0, height: 1080.0 }
-  , interactions: GInt.default
+  , window: GApp.Fullscreen
+  , behavior: GApp.defaultBehavior
+      { render = render
+      , update = update
+      }
   }
 
 update :: GTime.Delta -> GGeo.Scalers -> State -> Effect (Maybe State)

--- a/examples/clock/src/Main.purs
+++ b/examples/clock/src/Main.purs
@@ -12,10 +12,9 @@ import Effect (Effect)
 import Effect.Now (nowTime) as Now
 import Gesso (runGessoAff, awaitBody, run) as G
 import Gesso.Application as GApp
-import Gesso.Canvas (component, Input) as GC
-import Gesso.Geometry as GGeo
-import Gesso.Interactions as GInt
+import Gesso.Canvas (component) as GC
 import Gesso.Geometry ((-@), (~>@))
+import Gesso.Geometry as GGeo
 import Gesso.Time as GTime
 import Gesso.Util.Lerp as GLerp
 import Graphics.Canvas as Canvas
@@ -29,17 +28,13 @@ main =
 -- localState is unit because it's an input for run and needs to be
 --   passed in. The rest can be open because we never need to use them
 --   unless we call query or set the OutputMode to OutputFn
-input :: forall i o. GC.Input Unit i o
+input :: forall i o. GApp.AppSpec Unit i o
 input =
   { name: "test-app"
-  , localState: unit
-  , app:
-      GApp.defaultApp
-        { window = GApp.Fullscreen
-        , render = render
-        }
+  , initialState: unit
+  , window: GApp.Fullscreen
   , viewBox: { x: 0.0, y: 0.0, width: 1920.0, height: 1080.0 }
-  , interactions: GInt.default
+  , behavior: GApp.defaultBehavior { render = render }
   }
 
 render :: Canvas.Context2D -> GTime.Delta -> GGeo.Scalers -> GLerp.Lerp Unit -> Effect Unit

--- a/examples/controlling-ball/src/Main.purs
+++ b/examples/controlling-ball/src/Main.purs
@@ -7,7 +7,6 @@ import Data.Number (pi)
 import Effect (Effect)
 import Gesso as Gesso
 import Gesso.Application as GApp
-import Gesso.Canvas as GCan
 import Gesso.Geometry as GGeo
 import Gesso.Interactions as GInt
 import Gesso.Time as GTime
@@ -25,18 +24,17 @@ type State = { x :: Number, y :: Number, radius :: Number, keys :: Keys }
 
 type Keys = { up :: Boolean, down :: Boolean, left :: Boolean, right :: Boolean }
 
-canvasInput :: forall i o. GCan.Input State i o
+canvasInput :: forall i o. GApp.AppSpec State i o
 canvasInput =
   { name: "controlling-ball"
-  , localState: { x: 100.0, y: 100.0, radius: 25.0, keys: { up: false, down: false, left: false, right: false } }
-  , app:
-      GApp.defaultApp
-        { window = GApp.Fullscreen
-        , render = render
-        , update = update
-        }
+  , initialState: { x: 100.0, y: 100.0, radius: 25.0, keys: { up: false, down: false, left: false, right: false } }
   , viewBox: { x: 0.0, y: 0.0, width: 1920.0, height: 1080.0 }
-  , interactions: GInt.default { keyboard = [ keyDown, keyUp ], mouse = [ mouseDown ] }
+  , window: GApp.Fullscreen
+  , behavior: GApp.defaultBehavior
+      { render = render
+      , update = update
+      , interactions { keyboard = [ keyDown, keyUp ], mouse = [ mouseDown ] }
+      }
   }
 
 mouseDown :: GInt.MouseInteraction State

--- a/examples/hello/src/Main.purs
+++ b/examples/hello/src/Main.purs
@@ -3,9 +3,7 @@ module Example.Hello.Main where
 import Effect (Effect)
 import Gesso as Gesso
 import Gesso.Application as Gesso.Application
-import Gesso.Canvas as Gesso.Canvas
 import Gesso.Geometry as Gesso.Geometry
-import Gesso.Interactions as Gesso.Interactions
 import Gesso.Time as Gesso.Time
 import Gesso.Util.Lerp as Gesso.Util.Lerp
 import Graphics.Canvas as Graphics.Canvas
@@ -21,17 +19,13 @@ main =
 --   - local state (state held in canvas and given to update/render)
 --   - input (type used to send data into canvas)
 --   - output (type canvas uses to send data out)
-canvasInput :: forall i o. Gesso.Canvas.Input Unit i o
+canvasInput :: forall i o. Gesso.Application.AppSpec Unit i o
 canvasInput =
   { name: "hello"
-  , localState: unit
-  , app:
-      Gesso.Application.defaultApp
-        { window = Gesso.Application.Fullscreen
-        , render = render
-        }
+  , initialState: unit
   , viewBox: { x: 0.0, y: 0.0, width: 1920.0, height: 1080.0 }
-  , interactions: Gesso.Interactions.default
+  , window: Gesso.Application.Fullscreen
+  , behavior: Gesso.Application.defaultBehavior { render = render }
   }
 
 render :: Graphics.Canvas.Context2D -> Gesso.Time.Delta -> Gesso.Geometry.Scalers -> Gesso.Util.Lerp.Lerp Unit -> Effect Unit

--- a/examples/interpolation/src/Main.purs
+++ b/examples/interpolation/src/Main.purs
@@ -7,10 +7,8 @@ import Data.Maybe (Maybe(..))
 import Data.Number (abs, pi)
 import Effect (Effect)
 import Gesso as Gesso
-import Gesso.Application (defaultApp, WindowMode(..))
-import Gesso.Canvas (Input)
+import Gesso.Application (AppSpec, defaultBehavior, WindowMode(..))
 import Gesso.Geometry as GGeo
-import Gesso.Interactions as Interactions
 import Gesso.Time (Delta, hz) as Time
 import Gesso.Util.Lerp (Lerp, lerp)
 import Graphics.Canvas as Canvas
@@ -33,17 +31,16 @@ type State = { ball :: Ball, seconds :: Number }
 initialState :: State
 initialState = { ball: { x: 75.0, y: 100.0, vx: 0.3, r: 50.0 }, seconds: 0.0 }
 
-canvasInput :: forall i o. Input State i o
+canvasInput :: forall i o. AppSpec State i o
 canvasInput =
   { name: "interpolation"
-  , localState: initialState
-  , app: defaultApp
-      { window = Fullscreen
-      , render = render
+  , initialState
+  , window: Fullscreen
+  , viewBox: { x: 0.0, y: 0.0, width: 1920.0, height: 1080.0 }
+  , behavior: defaultBehavior
+      { render = render
       , fixed = { interval: Time.hz 20.0, function: fixedUpdate }
       }
-  , viewBox: { x: 0.0, y: 0.0, width: 1920.0, height: 1080.0 }
-  , interactions: Interactions.default
   }
 
 fixedUpdate :: Time.Delta -> GGeo.Scalers -> State -> Effect (Maybe State)

--- a/examples/paint/src/Grid.purs
+++ b/examples/paint/src/Grid.purs
@@ -18,9 +18,9 @@ import Effect (Effect)
 import Effect.Aff.Class (class MonadAff)
 import Gesso.Application as GApp
 import Gesso.Canvas as GC
+import Gesso.Geometry ((>@), (^@), (~>@), (-@))
 import Gesso.Geometry as GGeo
 import Gesso.Interactions as GInt
-import Gesso.Geometry ((>@), (^@), (~>@), (-@))
 import Gesso.Time as GTime
 import Gesso.Util.Lerp as GLerp
 import Graphics.Canvas as Canvas
@@ -57,7 +57,7 @@ type Slot s = (gessoCanvas :: GC.Slot CanvasIO CanvasIO Unit | s)
 component
   :: forall action slots m
    . MonadAff m
-  => (GC.Output CanvasIO -> action)
+  => (GC.CanvasOutput CanvasIO -> action)
   -> HH.ComponentHTML action (Slot slots) m
 component action =
   HH.slot GC._gessoCanvas unit GC.component canvasInput action
@@ -78,19 +78,18 @@ localState =
     , mouseDown: false
     }
 
-canvasInput :: GC.Input CanvasState CanvasIO CanvasIO
+canvasInput :: GApp.AppSpec CanvasState CanvasIO CanvasIO
 canvasInput =
   { name: "canvas"
-  , localState
-  , app:
-      GApp.defaultApp
-        { window = GApp.Fixed { width: 600.0, height: 600.0 }
-        , render = renderApp
-        , output = extractOutput
-        , input = convertState
-        }
+  , initialState: localState
+  , window: GApp.Fixed { width: 600.0, height: 600.0 }
   , viewBox: { x: 0.0, y: 0.0, width: 32.0, height: 32.0 }
-  , interactions: GInt.default { mouse = [ highlightCell, clearHighlight, mouseDown, mouseUp ] }
+  , behavior: GApp.defaultBehavior
+      { render = renderApp
+      , output = extractOutput
+      , input = convertState
+      , interactions { mouse = [ highlightCell, clearHighlight, mouseDown, mouseUp ] }
+      }
   }
 
 convertState

--- a/examples/paint/src/Root.purs
+++ b/examples/paint/src/Root.purs
@@ -26,7 +26,7 @@ data Action
   | Undo
   | Redo
   | ToggleGrid
-  | GotOutput (GC.Output CanvasIO)
+  | GotOutput (GC.CanvasOutput CanvasIO)
 
 component
   :: forall q i o m
@@ -115,7 +115,7 @@ render state =
 
 send :: forall o m. MonadAff m => CanvasIO -> H.HalogenM CanvasIO Action Slots o m Unit
 send state = do
-  H.tell GC._gessoCanvas unit $ GC.Input $ toIO state
+  H.tell GC._gessoCanvas unit $ GC.CanvasInput $ toIO state
   pure unit
 
 handleAction
@@ -125,7 +125,7 @@ handleAction
   -> H.HalogenM CanvasIO Action Slots o m Unit
 handleAction = case _ of
   ToggleGrid -> (H.modify \s -> s { showGrid = not s.showGrid } :: CanvasIO) >>= send
-  GotOutput (GC.Output output') -> H.put output'
+  GotOutput (GC.CanvasOutput output') -> H.put output'
   ButtonClicked (CB.Clicked color') -> H.modify (_ { color = color' }) >>= send
   Undo -> do
     state <- H.get

--- a/examples/unit-grid/src/Main.purs
+++ b/examples/unit-grid/src/Main.purs
@@ -10,7 +10,7 @@ import Data.Number (tau)
 import Effect (Effect)
 import Gesso (runGessoAff, awaitBody, run) as G
 import Gesso.Application as GApp
-import Gesso.Canvas (component, Input) as GC
+import Gesso.Canvas (component) as GC
 import Gesso.Geometry ((^@), (>@), (-@), to)
 import Gesso.Geometry as GGeo
 import Gesso.Interactions as GInt
@@ -29,17 +29,17 @@ type LocalState =
   , clicked :: Maybe GGeo.Point
   }
 
-input :: forall i o. GC.Input LocalState i o
+input :: forall i o. GApp.AppSpec LocalState i o
 input =
   { name: "test-app"
-  , localState: { mousePos: Nothing, clicked: Nothing }
-  , app:
-      GApp.defaultApp
-        { window = GApp.Fullscreen
-        , render = render
-        }
+  , initialState: { mousePos: Nothing, clicked: Nothing }
+  , window: GApp.Fullscreen
   , viewBox: { x: -1.5, y: -1.5, width: 3.0, height: 3.0 }
-  , interactions: GInt.default { mouse = [ mousePosition, mouseDown ] }
+  , behavior:
+      GApp.defaultBehavior
+        { render = render
+        , interactions { mouse = [ mousePosition, mouseDown ] }
+        }
   }
 
 mousePosition :: GInt.MouseInteraction LocalState

--- a/src/Gesso.purs
+++ b/src/Gesso.purs
@@ -21,6 +21,7 @@ import Prelude
 import Effect (Effect)
 import Effect.Aff (Aff)
 import Effect.Aff.Class (class MonadAff)
+import Gesso.Application as GApp
 import Gesso.Canvas as GCan
 import Halogen as H
 import Halogen.Aff (awaitBody, awaitLoad, selectElement) as Halogen.Aff
@@ -51,7 +52,7 @@ canvas
    . MonadAff m
   => H.Component
        (GCan.Query appInput)
-       (GCan.Input localState appInput appOutput)
+       (GApp.AppSpec localState appInput appOutput)
        (GCan.Output appOutput)
        m
 canvas = GCan.component

--- a/src/Gesso.purs
+++ b/src/Gesso.purs
@@ -51,8 +51,8 @@ canvas
   :: forall localState appInput appOutput m
    . MonadAff m
   => H.Component
-       (GCan.Query appInput)
+       (GCan.CanvasInput appInput)
        (GApp.AppSpec localState appInput appOutput)
-       (GCan.Output appOutput)
+       (GCan.CanvasOutput appOutput)
        m
 canvas = GCan.component

--- a/src/Gesso/Application.purs
+++ b/src/Gesso/Application.purs
@@ -1,54 +1,72 @@
 -- | `Application` houses functions and configuration that are shared between
 -- | all Gesso applications, regardless of the rendering component.
 module Gesso.Application
-  ( AppSpec
+  ( AppBehavior
+  , AppSpec
   , WindowMode(..)
-  , defaultApp
+  , defaultBehavior
   , module Exports
   ) where
 
 import Prelude
 
 import Data.Maybe (Maybe(..))
-import Effect (Effect)
-import Gesso.Geometry (Area, Rect, sizeless)
 import Gesso.Application.Behavior (FixedUpdate, InputReceiver, OutputProducer, RenderFunction, UpdateFunction)
 import Gesso.Application.Behavior (FixedUpdate, InputReceiver, OutputProducer, RenderFunction, TimestampedUpdate, UpdateFunction) as Exports
+import Gesso.Geometry (Area, Rect)
 import Gesso.Interactions (Interactions)
+import Gesso.Interactions (default) as Interactions
 import Gesso.Time (never)
 
 -- | `AppSpec` holds information about the setup and behavior of a Gesso
 -- | component.
 -- |
+-- | - `name` is the name of the application, which doubles as the HTML `id` for
+-- |   the canvas element.
+-- | - `initialState` is the initial local state for the application.
+-- | - `viewBox` is the desired dimensions for the drawing area.
 -- | - `window` defines how the screen element should size and position itself.
+-- | - `behavior` contains functions that control i/o, updates, and rendering.
+type AppSpec state input output =
+  { name :: String
+  , initialState :: state
+  , viewBox :: Rect
+  , window :: WindowMode
+  , behavior :: AppBehavior state input output
+  }
+
+-- | `AppBehavior` holds the functions that make an application run.
+-- |
 -- | - `render` draws on the component every animation frame.
 -- | - `update` runs on each animation frame, just before `render`.
+-- | - `fixed` runs at a set interval of time.
+-- | - `interactions` are events which will be attached to the canvas element.
 -- | - `output` defines how (or if) the component should send information out to
 -- |   the host application.
 -- | - `input` defines how the component's state should change in response to
 -- |   receiving input from the host application.
-type AppSpec local input output =
-  { window :: WindowMode
-  , render :: RenderFunction local
-  , fixed :: FixedUpdate local
-  , update :: UpdateFunction local
-  , output :: OutputProducer local output
-  , input :: InputReceiver local input
+type AppBehavior state input output =
+  { render :: RenderFunction state
+  , update :: UpdateFunction state
+  , fixed :: FixedUpdate state
+  , interactions :: Interactions state
+  , output :: OutputProducer state output
+  , input :: InputReceiver state input
   }
 
--- | A default `AppSpec` which can be modified piecemeal like Halogen's
+-- | A default `AppBehavior` which can be modified piecemeal like Halogen's
 -- | `EvalSpec`. It does nothing on its own.
-defaultApp
-  :: forall local input output
-   . AppSpec local input output
-defaultApp =
-  { window: Fixed sizeless
-  , render: \_ _ _ _ -> pure unit
+defaultBehavior
+  :: forall state input output
+   . AppBehavior state input output
+defaultBehavior =
+  { render: \_ _ _ _ -> pure unit
+  , update: \_ _ _ -> pure Nothing
   , fixed:
       { interval: never
       , function: \_ _ _ -> pure Nothing
       }
-  , update: \_ _ _ -> pure Nothing
+  , interactions: Interactions.default
   , output: \_ _ _ -> pure Nothing
   , input: \_ _ _ _ -> pure Nothing
   }

--- a/src/Gesso/Application.purs
+++ b/src/Gesso/Application.purs
@@ -19,6 +19,7 @@ import Effect (Effect)
 import Gesso.Geometry as Geo
 import Gesso.Util.Lerp (Versions, Lerp)
 import Gesso.Time as T
+import Graphics.Canvas (Context2D)
 
 -- | `AppSpec` holds information about the setup and behavior of a Gesso
 -- | component.
@@ -30,9 +31,9 @@ import Gesso.Time as T
 -- |   the host application.
 -- | - `input` defines how the component's state should change in response to
 -- |   receiving input from the host application.
-type AppSpec context local input output =
+type AppSpec local input output =
   { window :: WindowMode
-  , render :: RenderFunction context local
+  , render :: RenderFunction local
   , fixed :: FixedUpdate local
   , update :: UpdateFunction local
   , output :: OutputProducer local output
@@ -42,8 +43,8 @@ type AppSpec context local input output =
 -- | A default `AppSpec` which can be modified piecemeal like Halogen's
 -- | `EvalSpec`. It does nothing on its own.
 defaultApp
-  :: forall context local input output
-   . AppSpec context local input output
+  :: forall local input output
+   . AppSpec local input output
 defaultApp =
   { window: Fixed Geo.sizeless
   , render: \_ _ _ _ -> pure unit
@@ -70,7 +71,7 @@ data WindowMode
 
 -- | A function that draws on the component. It knows the following:
 -- |
--- | - `context` is the drawing context of canvas element, like `Context2D`
+-- | - `Context2D` is the drawing context of the canvas element
 -- | - `Delta` is a record containing current and previous timestamps and the
 -- |   time elapsed since the previous frame.
 -- | - `Scalers` is a record containing scaling information for transforming
@@ -80,8 +81,8 @@ data WindowMode
 -- |
 -- | The render function may run any operations in `Effect`, not just functions
 -- | related to drawing on the canvas.
-type RenderFunction context local =
-  context -> T.Delta -> Geo.Scalers -> Lerp local -> Effect Unit
+type RenderFunction local =
+  Context2D -> T.Delta -> Geo.Scalers -> Lerp local -> Effect Unit
 
 -- | An function that may update the application state. It runs on every frame,
 -- | before the render function. It knows the following:

--- a/src/Gesso/Application.purs
+++ b/src/Gesso/Application.purs
@@ -2,24 +2,20 @@
 -- | all Gesso applications, regardless of the rendering component.
 module Gesso.Application
   ( AppSpec
-  , FixedUpdate
-  , InputReceiver
-  , OutputProducer
-  , RenderFunction
-  , TimestampedUpdate
-  , UpdateFunction
   , WindowMode(..)
   , defaultApp
+  , module Exports
   ) where
 
 import Prelude
 
 import Data.Maybe (Maybe(..))
 import Effect (Effect)
-import Gesso.Geometry as Geo
-import Gesso.Util.Lerp (Versions, Lerp)
-import Gesso.Time as T
-import Graphics.Canvas (Context2D)
+import Gesso.Geometry (Area, Rect, sizeless)
+import Gesso.Application.Behavior (FixedUpdate, InputReceiver, OutputProducer, RenderFunction, UpdateFunction)
+import Gesso.Application.Behavior (FixedUpdate, InputReceiver, OutputProducer, RenderFunction, TimestampedUpdate, UpdateFunction) as Exports
+import Gesso.Interactions (Interactions)
+import Gesso.Time (never)
 
 -- | `AppSpec` holds information about the setup and behavior of a Gesso
 -- | component.
@@ -46,10 +42,10 @@ defaultApp
   :: forall local input output
    . AppSpec local input output
 defaultApp =
-  { window: Fixed Geo.sizeless
+  { window: Fixed sizeless
   , render: \_ _ _ _ -> pure unit
   , fixed:
-      { interval: T.never
+      { interval: never
       , function: \_ _ _ -> pure Nothing
       }
   , update: \_ _ _ -> pure Nothing
@@ -65,60 +61,6 @@ defaultApp =
 -- | - `FullScreen` takes up the entire page from the top left corner to the
 -- |   bottom right.
 data WindowMode
-  = Fixed Geo.Area
+  = Fixed Area
   | Stretch
   | Fullscreen
-
--- | A function that draws on the component. It knows the following:
--- |
--- | - `Context2D` is the drawing context of the canvas element
--- | - `Delta` is a record containing current and previous timestamps and the
--- |   time elapsed since the previous frame.
--- | - `Scalers` is a record containing scaling information for transforming
--- |   coordinates between the drawing and the canvas.
--- | - `local` is the local state of the application, with `Lerp` being the two
--- |   most recent states and the time progress between them.
--- |
--- | The render function may run any operations in `Effect`, not just functions
--- | related to drawing on the canvas.
-type RenderFunction local =
-  Context2D -> T.Delta -> Geo.Scalers -> Lerp local -> Effect Unit
-
--- | An function that may update the application state. It runs on every frame,
--- | before the render function. It knows the following:
--- |
--- | - `Delta` is a record containing current and previous timestamps and the
--- |   time elapsed since the previous frame.
--- | - `Scalers` is a record containing scaling information for transforming
--- |   coordinates between the drawing and the canvas.
--- | - `local` is the local state of the application
--- |
--- | The update function may return a new local state if changes are necessary
--- | (or `Nothing` if not).
--- |
--- | This type is also used by Interaction handlers and when receiving input
--- | from a host application.
-type UpdateFunction local =
-  T.Delta -> TimestampedUpdate local
-
--- | A partially applied `UpdateFunction` that already has the `Delta` record.
-type TimestampedUpdate local =
-  Geo.Scalers -> local -> Effect (Maybe local)
-
--- | An update function that occurs at a fixed, regular interval, rather than on
--- | every animation frame, which may vary.
-type FixedUpdate local =
-  { interval :: T.Interval
-  , function :: UpdateFunction local
-  }
-
--- | An input receiver is a variant of an update function that can receive
--- | information from the component's parent and produce an update function
--- | in response.
-type InputReceiver local input = input -> UpdateFunction local
-
--- | When the local state of an application changes, an output producer compares
--- | the old and new local states and may send output to the component's parent
--- | based on the difference.
-type OutputProducer local output =
-  T.Delta -> Geo.Scalers -> Versions local -> Effect (Maybe output)

--- a/src/Gesso/Application/Behavior.purs
+++ b/src/Gesso/Application/Behavior.purs
@@ -1,0 +1,71 @@
+module Gesso.Application.Behavior
+  ( FixedUpdate
+  , InputReceiver
+  , OutputProducer
+  , RenderFunction
+  , TimestampedUpdate
+  , UpdateFunction
+  ) where
+
+import Prelude
+
+import Data.Maybe (Maybe)
+import Effect (Effect)
+import Gesso.Geometry (Scalers)
+import Gesso.Time (Delta, Interval)
+import Gesso.Util.Lerp (Versions, Lerp)
+import Graphics.Canvas (Context2D)
+
+-- | A function that draws on the component. It knows the following:
+-- |
+-- | - `Context2D` is the drawing context of the canvas element
+-- | - `Delta` is a record containing current and previous timestamps and the
+-- |   time elapsed since the previous frame.
+-- | - `Scalers` is a record containing scaling information for transforming
+-- |   coordinates between the drawing and the canvas.
+-- | - `local` is the local state of the application, with `Lerp` being the two
+-- |   most recent states and the time progress between them.
+-- |
+-- | The render function may run any operations in `Effect`, not just functions
+-- | related to drawing on the canvas.
+type RenderFunction local =
+  Context2D -> Delta -> Scalers -> Lerp local -> Effect Unit
+
+-- | An function that may update the application state. It runs on every frame,
+-- | before the render function. It knows the following:
+-- |
+-- | - `Delta` is a record containing current and previous timestamps and the
+-- |   time elapsed since the previous frame.
+-- | - `Scalers` is a record containing scaling information for transforming
+-- |   coordinates between the drawing and the canvas.
+-- | - `local` is the local state of the application
+-- |
+-- | The update function may return a new local state if changes are necessary
+-- | (or `Nothing` if not).
+-- |
+-- | This type is also used by Interaction handlers and when receiving input
+-- | from a host application.
+type UpdateFunction local =
+  Delta -> TimestampedUpdate local
+
+-- | A partially applied `UpdateFunction` that already has the `Delta` record.
+type TimestampedUpdate local =
+  Scalers -> local -> Effect (Maybe local)
+
+-- | An update function that occurs at a fixed, regular interval, rather than on
+-- | every animation frame, which may vary.
+type FixedUpdate local =
+  { interval :: Interval
+  , function :: UpdateFunction local
+  }
+
+-- | An input receiver is a variant of an update function that can receive
+-- | information from the component's parent and produce an update function
+-- | in response.
+type InputReceiver local input = input -> UpdateFunction local
+
+-- | When the local state of an application changes, an output producer compares
+-- | the old and new local states and may send output to the component's parent
+-- | based on the difference.
+type OutputProducer local output =
+  Delta -> Scalers -> Versions local -> Effect (Maybe output)

--- a/src/Gesso/Canvas.purs
+++ b/src/Gesso/Canvas.purs
@@ -85,7 +85,7 @@ _gessoCanvas = Proxy :: Proxy "gessoCanvas"
 -- |   frame callback runs.
 type State localState appInput appOutput =
   { name :: String
-  , app :: App.AppSpec Context2D localState appInput appOutput
+  , app :: App.AppSpec localState appInput appOutput
   , localState :: localState
   , viewBox :: Geo.Rect
   , interactions :: GI.Interactions localState
@@ -151,7 +151,7 @@ data Query appInput a = Input appInput a
 -- |    canvas element.
 type Input localState appInput appOutput =
   { name :: String
-  , app :: App.AppSpec Context2D localState appInput appOutput
+  , app :: App.AppSpec localState appInput appOutput
   , localState :: localState
   , viewBox :: Geo.Rect
   , interactions :: GI.Interactions localState
@@ -409,7 +409,7 @@ queueAnimationFrame
   -> Context2D
   -> Geo.Scalers
   -> History localState
-  -> App.AppSpec Context2D localState appInput appOutput
+  -> App.AppSpec localState appInput appOutput
   -> (Action localState -> Effect Unit)
   -> Effect Unit
 queueAnimationFrame lastTime toIntRatio context scalers stateHistory app notify =

--- a/src/Gesso/Interactions/Internal.purs
+++ b/src/Gesso/Interactions/Internal.purs
@@ -10,7 +10,7 @@ module Gesso.Interactions.Internal
 import Prelude
 
 import DOM.HTML.Indexed (HTMLcanvas)
-import Gesso.Application (UpdateFunction) as App
+import Gesso.Application.Behavior (UpdateFunction) as App
 import Halogen.HTML.Properties (IProp)
 import Web.Clipboard.ClipboardEvent (ClipboardEvent) as Exports
 import Web.Event.Internal.Types (Event) as Exports


### PR DESCRIPTION
Closes #18.

The difference between `Gesso.Application.AppSpec` and `Gesso.Canvas.Input` was unclear, and the naming of  `Gesso.Canvas.Input` was confusing (unrelated to `Gesso.Canvas.Output`, whose counterpart was `Gesso.Canvas.Query`).

This combines and re-splits `AppSpec` and `Input` into `Gesso.Application.AppSpec` and `Gesso.Application.AppBehavior`, where `Behavior` contains all render/update/io functions (which can all be defaulted to do nothing), and `Spec` contains data which would be difficult or impossible to default (name, state, viewbox, window).

`Spec` also contains `Behavior` as Halogen's `runUI` only allows one input field.