### PR TITLE
Fix order of timestamped updates

### DIFF
--- a/spago.yaml
+++ b/spago.yaml
@@ -28,7 +28,7 @@ package:
     - web-touchevents: ">=4.0.0 <5.0.0"
     - web-uievents: ">=4.0.0 <6.0.0"
   publish:
-    version: 1.0.0
+    version: 1.0.1
     license: MIT
     exclude:
       - "examples/*"

--- a/src/Gesso/Canvas.purs
+++ b/src/Gesso/Canvas.purs
@@ -12,7 +12,7 @@ module Gesso.Canvas
 import Prelude
 
 import Control.Monad.Maybe.Trans (MaybeT(..), lift, runMaybeT)
-import Data.Foldable (foldr, for_, traverse_)
+import Data.Foldable (foldl, for_, traverse_)
 import Data.Function (on)
 import Data.List (List, (:))
 import Data.List as List
@@ -271,8 +271,8 @@ handleAction = case _ of
             , changed: false
             }
         stateHistory <-
-          foldr
-            (tryUpdate scalers)
+          foldl
+            (flip $ tryUpdate scalers)
             (pure initialHistory)
             (updateQueue <#> _.item)
 

--- a/src/Gesso/Canvas.purs
+++ b/src/Gesso/Canvas.purs
@@ -14,7 +14,7 @@ import Prelude
 import Control.Monad.Maybe.Trans (MaybeT(..), lift, runMaybeT)
 import Data.Foldable (foldl, for_, traverse_)
 import Data.Function (on)
-import Data.List (List, (:))
+import Data.List (List, snoc)
 import Data.List as List
 import Data.Maybe (Maybe(..), maybe)
 import Data.Traversable (for, traverse)
@@ -303,7 +303,12 @@ handleAction = case _ of
     { pendingUpdates, timers } <- H.get
     for_ timers \{ frame } -> do
       stampedUpdate <- H.liftEffect $ T.stamp frame handlerFn
-      H.modify_ (_ { pendingUpdates = stampedUpdate : pendingUpdates })
+      -- The new update has to be appended to keep the event order correct. When
+      -- events are prepended, events with a specified order (e.g. `keydown`
+      -- must always precede `keyup`*), can get reversed if they have the exact
+      -- same timestamp. (Issue #55)
+      -- * https://w3c.github.io/uievents/#event-type-keydown
+      H.modify_ (_ { pendingUpdates = snoc pendingUpdates stampedUpdate })
 
   StateUpdated delta scalers stateVersions ->
     saveNewState delta scalers stateVersions


### PR DESCRIPTION
In `Gesso.Canvas.handleAction`, in the `Tick` case, queued updates are sorted by the time they arrived, ascending, but they were applied with a right fold, so in certain cases events were reversed.

This change makes it a left fold instead.

Fixes #55